### PR TITLE
FIXED: warning • lib\custom_page_flip.dart:68:36 • The value of the f…

### DIFF
--- a/lib/custom_page_flip.dart
+++ b/lib/custom_page_flip.dart
@@ -65,7 +65,7 @@ class CustomPageFlip extends StatefulWidget {
 }
 
 
-enum _GestureMode { none, scaling, dragging }
+enum _GestureMode { none, scaling }
 
 class CustomPageFlipState extends State<CustomPageFlip>
     with TickerProviderStateMixin {


### PR DESCRIPTION
…ield 'dragging' isn't used. Try removing the field, or